### PR TITLE
ci(workflows): refactor main workflow to parallelize SDK builds and remove unused steps

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,9 +10,12 @@ name: main
       - sdk/*
       - "**"
 
+env:
+  PROVIDER_NAME: pulumi-resource-kubeconfig
+
 jobs:
-  build_sdks:
-    name: Build SDKs
+  build_provider:
+    name: Build Provider binary
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -24,42 +27,103 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24.x"
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20.x"
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: "6.0.302"
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
+          go-version: "1.26.x"
+          cache: true
+          cache-dependency-path: "go.sum"
       - name: Install Pulumi CLI
         uses: pulumi/actions@v6
         with:
           pulumi-version: latest
       - name: Check Pulumi CLI version
         run: pulumi version
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
+        with:
+          repo: pulumi/pulumictl
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build provider
+        run: task build_provider
+      - name: Tar provider binaries
+        run: tar -zcf ${{ github.workspace }}/bin/${{ env.PROVIDER_NAME }}.tar.gz -C ${{ github.workspace }}/bin/ ${{ env.PROVIDER_NAME }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.PROVIDER_NAME }}.tar.gz
+          path: ${{ github.workspace }}/bin/${{ env.PROVIDER_NAME }}.tar.gz
+  
+  build_sdks:
+    name: Build provider SDKs
+    runs-on: ubuntu-latest
+    needs: build_provider
+    strategy:
+        fail-fast: true
+        matrix:
+          language:
+            - nodejs
+            - python
+            - dotnet
+            - go
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+      - name: Set Provider Version
+        uses: pulumi/provider-version-action@v1
+        with:
+          set-env: PROVIDER_VERSION
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v6
+        with:
+          pulumi-version: latest
+      - name: Check Pulumi CLI version
+        run: pulumi version
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:
           repo: pulumi/pulumictl
-      - name: generate sdks
-        run: task generate_sdks
-      - name: Check worktree clean
-        uses: pulumi/git-status-check-action@v1
+      - if: matrix.language == 'nodejs' 
+        name: Setup Node
+        uses: actions/setup-node@v6
         with:
-          allowed-changes: |-
-            sdk/**/pulumi-plugin.json
-            sdk/dotnet/PiersKarsenbarg.*.csproj
-            sdk/go/**/pulumiUtilities.go
-            sdk/nodejs/package.json
-            sdk/python/pyproject.toml
+          node-version: "22.x"
+      - if: matrix.language == 'dotnet'
+        name: Setup DotNet
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.201"
+      - if: matrix.language == 'python'
+        name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - if: matrix.language == 'go'
+        name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.x"
+      - name: Download provider binary
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.PROVIDER_NAME }}.tar.gz
+          path: ${{ github.workspace }}/bin
+      - name: Untar provider binary
+        run: |-
+          tar -zxf ${{ github.workspace }}/bin/${{ env.PROVIDER_NAME }}.tar.gz -C ${{ github.workspace }}/bin
+          chmod +x ${{ github.workspace }}/bin/${{ env.PROVIDER_NAME }}
+      - name: Build ${{ matrix.language }} SDK
+        run: task generate_${{ matrix.language }}_sdk
+      - name: Compress SDK folder
+        run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.language  }}-sdk.tar.gz
+          path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
-      - name: Get short commit sha
-        id: short_commit_sha
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Set Provider Version
         uses: pulumi/provider-version-action@v1
         with:
@@ -65,9 +62,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
-      - name: Get short commit sha
-        id: short_commit_sha
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Set Provider Version
         uses: pulumi/provider-version-action@v1
         with:


### PR DESCRIPTION
- Separate provider build from SDK builds in main.yaml
- Add matrix strategy for parallel SDK generation (nodejs, python, dotnet, go)
- Update versions: Go 1.26.x, Node 22.x, .NET 10.0.201
- Add PROVIDER_NAME env variable for consistency
- Remove unused short_commit_sha extraction steps from pr.yaml
- Remove git-status-check-action as SDK generation is now separate
